### PR TITLE
Fix flaky tests caused by int overflow

### DIFF
--- a/store/src/main/java/com/epam/eco/schemacatalog/store/metadata/InheritingMetadataContainer.java
+++ b/store/src/main/java/com/epam/eco/schemacatalog/store/metadata/InheritingMetadataContainer.java
@@ -274,7 +274,7 @@ public class InheritingMetadataContainer implements MetadataContainer {
 
         @Override
         public int hashCode() {
-            return HashCodeBuilder.reflectionHashCode(key, "version");
+            return HashCodeBuilder.reflectionHashCode(1, 1, key, false, null, "version");
         }
 
     }


### PR DESCRIPTION
## What's the purpose of this PR

Fix test `InheritingMetadataContainerTest`

## Which issue(s) this PR fixes:

Fixes the issue that causes flaky tests. 
The current test would fail in some circumstances and I found it using [NonDex](https://github.com/TestingResearchIllinois/NonDex) by running the command -
`mvn -pl store edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=com.epam.eco.schemacatalog.store.metadata.InheritingMetadataContainerTest#testPut1`

There is a built-in disadvantage with [HashCodeBuilder.reflectionHashCode](https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/builder/HashCodeBuilder.html#reflectionHashCode-java.lang.Object-java.util.Collection-)([Object](https://docs.oracle.com/javase/7/docs/api/java/lang/Object.html?is-external=true) object, [Collection](https://docs.oracle.com/javase/7/docs/api/java/util/Collection.html?is-external=true)<[String](https://docs.oracle.com/javase/7/docs/api/java/lang/String.html?is-external=true)> excludeFields). It computes the hashcode by summing and multiplying the field values within the class and its inheritance and outputs an integer value as the hash value. However, it didn't handle the overflow issue when the number of fields was too large, leading the hash value to exceed the limit of the integer type. To solve this issue I used another method in `HashCodeBuilder` to specify the initial value and the multiplier to reduce the chance of test failure.

## Brief changelog

Change the method used for calculating hashcode.